### PR TITLE
Rand lasso deterministic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: monaLisa
 Type: Package
 Title: Binned Motif Enrichment Analysis and Visualization
-Version: 0.1.50
+Version: 0.2.0
 Authors@R: c(
     person("Dania", "Machlab", email = "dania.machlab@fmi.ch", role = c("aut"), comment = c(ORCID = "0000-0002-2578-6930")),
     person("Lukas", "Burger", email = "lukas.burger@fmi.ch", role = c("aut")),

--- a/R/stability_selection.R
+++ b/R/stability_selection.R
@@ -141,32 +141,31 @@ NULL
 #'   }
 #'   
 #' @examples 
-#'   library(monaLisa)
+#' library(monaLisa)
 #'   
-#'   # create artificial data set
-#'   Y <- rnorm(n = 500, mean = 2, sd = 1)
-#'   X <- matrix(data = NA, nrow = length(Y), ncol = 50)
-#'   for (i in seq_len(ncol(X))) {
-#'       X[ ,i] <- runif(n = 500, min = 0, max = 3)
-#'   }
-#'   s_cols <- sample(x = seq_len(ncol(X)), size = 10, 
-#'       replace = FALSE)
-#'   for (i in seq_along(s_cols)) {
-#'       X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
-#'   }
+#' ## create data set
+#' Y <- rnorm(n = 500, mean = 2, sd = 1)
+#' X <- matrix(data = NA, nrow = length(Y), ncol = 50)
+#' for (i in seq_len(ncol(X))) {
+#'   X[ ,i] <- runif(n = 500, min = 0, max = 3)
+#' }
+#' s_cols <- sample(x = seq_len(ncol(X)), size = 10, 
+#'   replace = FALSE)
+#' for (i in seq_along(s_cols)) {
+#'   X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
+#' }
 #'   
-#'   # reproducible randLassoStabSel() with 1 core
-#'   set.seed(123)
-#'   ss <- randLassoStabSel(x = X, y = Y)
+#' ## reproducible randLassoStabSel() with 1 core
+#' set.seed(123)
+#' ss <- randLassoStabSel(x = X, y = Y)
 #'   
-#'   # reproducible randLassoStabSel() in parallel mode 
-#'   # (only works on non-windows machines)
-#'   \dontrun{
-#'     RNGkind("L'Ecuyer-CMRG")
-#'     set.seed(123)
-#'     ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
-#'         mc.set.seed = TRUE, mc.cores = 2L)
-#'   }
+#' ## reproducible randLassoStabSel() in parallel mode 
+#' ## (only works on non-windows machines)
+#' \dontrun{
+#' RNGkind("L'Ecuyer-CMRG")
+#' set.seed(123)
+#' ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
+#'   mc.set.seed = TRUE, mc.cores = 2L)}
 #'
 #' @seealso \code{\link[stabs]{stabsel}}
 #'

--- a/R/stability_selection.R
+++ b/R/stability_selection.R
@@ -86,6 +86,9 @@ NULL
 #'   Any variable with a selection probability that is higher than the set cutoff will be selected.
 #' @param PFER integer (default = 2) representing the absolute number of false positives that we 
 #'   allow for in the final list of selected variables. For details see Meinshausen and Bühlmann (2010).
+#' @param mc.cores integer (default = 1) specifying the number of cores to use in 
+#'   \code{\link[parallel]{mclapply}}, which is the default way \code{\link[stabs]{stabsel}} 
+#'   does parallelization.
 #' @param ... additional parameters that can be passed on to \code{\link[stabs]{stabsel}}.
 #'
 #' @details Randomized lasso stability selection runs a randomized lasso regression 
@@ -136,8 +139,33 @@ NULL
 #'     }
 #'   
 #'   }
+#'   
+#' @examples 
+#'   library(monaLisa)
+#'   
+#'   # create artificial data set
+#'   Y <- rnorm(n = 500, mean = 2, sd = 1)
+#'   X <- matrix(data = NA, nrow = length(Y), ncol = 50)
+#'   for (i in seq_len(ncol(X))) {
+#'       X[ ,i] <- runif(n = 500, min = 0, max = 3)
+#'   }
+#'   s_cols <- sample(x = seq_len(ncol(X)), size = 10, 
+#'       replace = FALSE)
+#'   for (i in seq_along(s_cols)) {
+#'       X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
+#'   }
+#'   
+#'   # reproducible randLassoStabSel() with 1 core
+#'   set.seed(123)
+#'   ss <- randLassoStabSel(x = X, y = Y)
+#'   
+#'   # reproducible randLassoStabSel() in parallel mode
+#'   RNGkind("L'Ecuyer-CMRG")
+#'   set.seed(123)
+#'   ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
+#'       mc.set.seed = TRUE, mc.cores = 2L)
 #'
-#'@seealso \code{\link[stabs]{stabsel}}
+#' @seealso \code{\link[stabs]{stabsel}}
 #'
 #' @references N. Meinshausen and P. Bühlmann (2010), Stability Selection, \emph{Journal of the Royal Statistical Society: Series B (Statistical Methodology)}, \strong{72}, 417–73. \cr
 #'   R.D. Shah and R.J. Samworth (2013), Variable Selection with Error Control: Another Look at Stability Selection, \emph{Journal of the Royal Statistical Society: Series B (Statistical Methodology)}, \strong{75}, 55–80. \cr
@@ -147,7 +175,7 @@ NULL
 #' @importFrom SummarizedExperiment SummarizedExperiment
 #'
 #'@export
-randLassoStabSel <- function(x, y, weakness=0.8, cutoff=0.8, PFER=2, ...) {
+randLassoStabSel <- function(x, y, weakness=0.8, cutoff=0.8, PFER=2, mc.cores=1L, ...) {
   
     # checks
     if (!is(x, "matrix")) {
@@ -173,7 +201,7 @@ randLassoStabSel <- function(x, y, weakness=0.8, cutoff=0.8, PFER=2, ...) {
     # run randomized lasso stability selection
     ss <- stabs::stabsel(x = x, y = y, fitfun = .glmnetRandomizedLasso, 
                          args.fitfun = list(weakness = weakness),
-                         cutoff = cutoff, PFER = PFER, ...)
+                         cutoff = cutoff, PFER = PFER, mc.cores = mc.cores, ...)
 
     
     # restructure as SummarizedExperiment object

--- a/R/stability_selection.R
+++ b/R/stability_selection.R
@@ -159,11 +159,14 @@ NULL
 #'   set.seed(123)
 #'   ss <- randLassoStabSel(x = X, y = Y)
 #'   
-#'   # reproducible randLassoStabSel() in parallel mode
-#'   RNGkind("L'Ecuyer-CMRG")
-#'   set.seed(123)
-#'   ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
-#'       mc.set.seed = TRUE, mc.cores = 2L)
+#'   # reproducible randLassoStabSel() in parallel mode 
+#'   # (only works on non-windows machines)
+#'   \dontrun{
+#'     RNGkind("L'Ecuyer-CMRG")
+#'     set.seed(123)
+#'     ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
+#'         mc.set.seed = TRUE, mc.cores = 2L)
+#'   }
 #'
 #' @seealso \code{\link[stabs]{stabsel}}
 #'

--- a/man/dot-defineBackground.Rd
+++ b/man/dot-defineBackground.Rd
@@ -13,7 +13,7 @@
   gnm.regions,
   gnm.oversample,
   gnm.seed,
-  maxFracN,
+  maxFracN = 0.7,
   GCbreaks = c(0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8)
 )
 }

--- a/man/randLassoStabSel.Rd
+++ b/man/randLassoStabSel.Rd
@@ -93,32 +93,31 @@ Randomized lasso stability selection runs a randomized lasso regression
   and adapted it to run randomized lasso stability selection.
 }
 \examples{
-  library(monaLisa)
+library(monaLisa)
   
-  # create artificial data set
-  Y <- rnorm(n = 500, mean = 2, sd = 1)
-  X <- matrix(data = NA, nrow = length(Y), ncol = 50)
-  for (i in seq_len(ncol(X))) {
-      X[ ,i] <- runif(n = 500, min = 0, max = 3)
-  }
-  s_cols <- sample(x = seq_len(ncol(X)), size = 10, 
-      replace = FALSE)
-  for (i in seq_along(s_cols)) {
-      X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
-  }
+## create data set
+Y <- rnorm(n = 500, mean = 2, sd = 1)
+X <- matrix(data = NA, nrow = length(Y), ncol = 50)
+for (i in seq_len(ncol(X))) {
+  X[ ,i] <- runif(n = 500, min = 0, max = 3)
+}
+s_cols <- sample(x = seq_len(ncol(X)), size = 10, 
+  replace = FALSE)
+for (i in seq_along(s_cols)) {
+  X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
+}
   
-  # reproducible randLassoStabSel() with 1 core
-  set.seed(123)
-  ss <- randLassoStabSel(x = X, y = Y)
+## reproducible randLassoStabSel() with 1 core
+set.seed(123)
+ss <- randLassoStabSel(x = X, y = Y)
   
-  # reproducible randLassoStabSel() in parallel mode 
-  # (only works on non-windows machines)
-  \dontrun{
-    RNGkind("L'Ecuyer-CMRG")
-    set.seed(123)
-    ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
-        mc.set.seed = TRUE, mc.cores = 2L)
-  }
+## reproducible randLassoStabSel() in parallel mode 
+## (only works on non-windows machines)
+\dontrun{
+RNGkind("L'Ecuyer-CMRG")
+set.seed(123)
+ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
+  mc.set.seed = TRUE, mc.cores = 2L)}
 
 }
 \references{

--- a/man/randLassoStabSel.Rd
+++ b/man/randLassoStabSel.Rd
@@ -111,11 +111,14 @@ Randomized lasso stability selection runs a randomized lasso regression
   set.seed(123)
   ss <- randLassoStabSel(x = X, y = Y)
   
-  # reproducible randLassoStabSel() in parallel mode
-  RNGkind("L'Ecuyer-CMRG")
-  set.seed(123)
-  ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
-      mc.set.seed = TRUE, mc.cores = 2L)
+  # reproducible randLassoStabSel() in parallel mode 
+  # (only works on non-windows machines)
+  \dontrun{
+    RNGkind("L'Ecuyer-CMRG")
+    set.seed(123)
+    ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
+        mc.set.seed = TRUE, mc.cores = 2L)
+  }
 
 }
 \references{

--- a/man/randLassoStabSel.Rd
+++ b/man/randLassoStabSel.Rd
@@ -4,7 +4,15 @@
 \alias{randLassoStabSel}
 \title{Randomized Lasso Stability Selection}
 \usage{
-randLassoStabSel(x, y, weakness = 0.8, cutoff = 0.8, PFER = 2, ...)
+randLassoStabSel(
+  x,
+  y,
+  weakness = 0.8,
+  cutoff = 0.8,
+  PFER = 2,
+  mc.cores = 1L,
+  ...
+)
 }
 \arguments{
 \item{x}{the predictor matrix.}
@@ -21,6 +29,10 @@ Any variable with a selection probability that is higher than the set cutoff wil
 
 \item{PFER}{integer (default = 2) representing the absolute number of false positives that we 
 allow for in the final list of selected variables. For details see Meinshausen and Bühlmann (2010).}
+
+\item{mc.cores}{integer (default = 1), specifying the number of cores to use in 
+\code{\link[parallel]{mclapply}}, which is the default way \code{\link[stabs]{stabsel}} 
+does parallelization.}
 
 \item{...}{additional parameters that can be passed on to \code{\link[stabs]{stabsel}}.}
 }
@@ -79,6 +91,32 @@ Randomized lasso stability selection runs a randomized lasso regression
 
   We made use of the \code{stabs} package that implements lasso stability selection, 
   and adapted it to run randomized lasso stability selection.
+}
+\examples{
+  library(monaLisa)
+  
+  # create artificial data set
+  Y <- rnorm(n = 500, mean = 2, sd = 1)
+  X <- matrix(data = NA, nrow = length(Y), ncol = 50)
+  for (i in seq_len(ncol(X))) {
+      X[ ,i] <- runif(n = 500, min = 0, max = 3)
+  }
+  s_cols <- sample(x = seq_len(ncol(X)), size = 10, 
+      replace = FALSE)
+  for (i in seq_along(s_cols)) {
+      X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
+  }
+  
+  # reproducible randLassoStabSel() with 1 core
+  set.seed(123)
+  ss <- randLassoStabSel(x = X, y = Y)
+  
+  # reproducible randLassoStabSel() in parallel mode
+  RNGkind("L'Ecuyer-CMRG")
+  set.seed(123)
+  ss <- randLassoStabSel(x = X, y = Y, mc.preschedule = TRUE, 
+      mc.set.seed = TRUE, mc.cores = 2L)
+
 }
 \references{
 N. Meinshausen and P. Bühlmann (2010), Stability Selection, \emph{Journal of the Royal Statistical Society: Series B (Statistical Methodology)}, \strong{72}, 417–73. \cr

--- a/man/randLassoStabSel.Rd
+++ b/man/randLassoStabSel.Rd
@@ -30,7 +30,7 @@ Any variable with a selection probability that is higher than the set cutoff wil
 \item{PFER}{integer (default = 2) representing the absolute number of false positives that we 
 allow for in the final list of selected variables. For details see Meinshausen and Bühlmann (2010).}
 
-\item{mc.cores}{integer (default = 1), specifying the number of cores to use in 
+\item{mc.cores}{integer (default = 1) specifying the number of cores to use in 
 \code{\link[parallel]{mclapply}}, which is the default way \code{\link[stabs]{stabsel}} 
 does parallelization.}
 

--- a/tests/testthat/test_stability_selection.R
+++ b/tests/testthat/test_stability_selection.R
@@ -59,7 +59,7 @@ test_that("randLassoStabSel() is deterministic", {
   ss2 <- monaLisa::randLassoStabSel(x = X, y = Y)
   
   # tests
-  expect_identical(colData(ss1), colData(ss2))
+  expect_identical(ss1, ss2)
   
 })
 

--- a/tests/testthat/test_stability_selection.R
+++ b/tests/testthat/test_stability_selection.R
@@ -38,6 +38,31 @@ test_that("randLassoStabSel() works properly", {
     expect_error(randLassoStabSel(x = X2[1:100, ], y = Y2[2:100]))
 })
 
+test_that("randLassoStabSel() is deterministic", {
+  
+  # create data set
+  set.seed(555)
+  Y <- rnorm(n = 500, mean = 2, sd = 1)
+  X <- matrix(data = NA, nrow = length(Y), ncol = 50)
+  for (i in seq_len(ncol(X))) {
+    X[ ,i] <- runif(n = 500, min = 0, max = 3)
+  }
+  s_cols <- sample(x = seq_len(ncol(X)), size = 10, replace = FALSE)
+  for (i in seq_along(s_cols)) {
+    X[ ,s_cols[i]] <- X[ ,s_cols[i]] + Y
+  }
+  
+  # randomized lasso stability selection
+  set.seed(123)
+  ss1 <- monaLisa::randLassoStabSel(x = X, y = Y)
+  set.seed(123)
+  ss2 <- monaLisa::randLassoStabSel(x = X, y = Y)
+  
+  # tests
+  expect_identical(colData(ss1), colData(ss2))
+  
+})
+
 
 test_that(".glmnetRandomizedLasso() works properly", {
     # create data set

--- a/vignettes/monaLisa.Rmd
+++ b/vignettes/monaLisa.Rmd
@@ -435,9 +435,9 @@ We can now run randomized lasso stability selection to identify TFs that are lik
 ```{r stabSelTFs}
 # select TFs
 # ... randLassoStabSel() is stochastic, so we set a seed to reproduce the run
-set.seed(123)
-se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, mc.cores = 1)
-se
+# set.seed(123)
+# se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, mc.cores = 1)
+# se
 
 # # if using a Windows OS, parallelize using parLapply 
 # # ... (see stabs::stabsel for more details)
@@ -446,6 +446,16 @@ se
 # se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung,
 #                        cutoff = 0.8, papply = parLapply, cl = cl)
   
+library(parallel)
+cl <- makeCluster(4)
+set.seed(123);system.time(se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, papply = parLapply, cl = cl))
+set.seed(123);system.time(se2 <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, papply = parLapply, cl = cl))
+
+identical(colData(se), colData(se2))
+
+cl <- makeCluster(1)
+set.seed(123);system.time(se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, papply = parLapply, cl = cl))
+
 # selected TFs
 colnames(se)[se$selected]
 ```

--- a/vignettes/monaLisa.Rmd
+++ b/vignettes/monaLisa.Rmd
@@ -434,27 +434,15 @@ We can now run randomized lasso stability selection to identify TFs that are lik
 
 ```{r stabSelTFs}
 # select TFs
-# ... randLassoStabSel() is stochastic, so we set a seed to reproduce the run
-# set.seed(123)
-# se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, mc.cores = 1)
-# se
-
-# # if using a Windows OS, parallelize using parLapply 
-# # ... (see stabs::stabsel for more details)
-# library(parallel)
-# cl <- makeCluster(2)
-# se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung,
-#                        cutoff = 0.8, papply = parLapply, cl = cl)
-  
-library(parallel)
-cl <- makeCluster(4)
-set.seed(123);system.time(se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, papply = parLapply, cl = cl))
-set.seed(123);system.time(se2 <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, papply = parLapply, cl = cl))
-
-identical(colData(se), colData(se2))
-
-cl <- makeCluster(1)
-set.seed(123);system.time(se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, papply = parLapply, cl = cl))
+# ... randLassoStabSel() is stochastic, so we set a seed to reproduce a parallel run
+RNGkind("L'Ecuyer-CMRG")
+set.seed(123)
+se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, mc.preschedule = TRUE, mc.set.seed = TRUE, mc.cores = 2L)
+# ... if not running in parallel mode, it is enough to use set.seed() before using the function
+# ... ... to ensure reproducibility (with 1 core)
+set.seed(123)
+se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8)
+se
 
 # selected TFs
 colnames(se)[se$selected]

--- a/vignettes/monaLisa.Rmd
+++ b/vignettes/monaLisa.Rmd
@@ -433,13 +433,13 @@ TFBSmatrix[1:6, 1:6]
 We can now run randomized lasso stability selection to identify TFs that are likely to explain the log-fold changes in accessibility. 
 
 ```{r stabSelTFs}
-# select TFs
-# ... randLassoStabSel() is stochastic, so we set a seed to reproduce a parallel run
-RNGkind("L'Ecuyer-CMRG")
-set.seed(123)
-se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, mc.preschedule = TRUE, mc.set.seed = TRUE, mc.cores = 2L)
-# ... if not running in parallel mode, it is enough to use set.seed() before using the function
-# ... ... to ensure reproducibility (with 1 core)
+# # randLassoStabSel() is stochastic, so we set a seed to reproduce a parallel run
+# RNGkind("L'Ecuyer-CMRG")
+# set.seed(123)
+# se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8, mc.preschedule = TRUE, mc.set.seed = TRUE, mc.cores = 2L)
+
+# if not running in parallel mode, it is enough to use set.seed() before using the function
+# ... to ensure reproducibility (with 1 core)
 set.seed(123)
 se <- randLassoStabSel(x = TFBSmatrix, y = gr$logFC_liver_vs_lung, cutoff = 0.8)
 se


### PR DESCRIPTION
set `mc.cores=1` in `randLassoStabSel()`, so that it is deterministic when setting the seed before using the function. We also added a test that makes sure this is deterministic, and an example in the help page of the function and the vignette (both not run due to errors on GHA in windows machine) to illustrate how to reproducibly use the function in parallel mode.