### PR TITLE
Fix pearson resid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: monaLisa
 Type: Package
 Title: Binned Motif Enrichment Analysis and Visualization
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Dania", "Machlab", email = "dania.machlab@fmi.ch", role = c("aut"), comment = c(ORCID = "0000-0002-2578-6930")),
     person("Lukas", "Burger", email = "lukas.burger@fmi.ch", role = c("aut")),

--- a/R/motif_enrichment_HOMER.R
+++ b/R/motif_enrichment_HOMER.R
@@ -311,6 +311,11 @@ parseHomerOutput <- function(infiles,
     #     assuming expTF to be a Binomial random variable, with
     #       mean     = N_fg * p_bg
     #       variance = N_fg * p_bg * (1 - p_bg)
+    #     idea: each sequence is one trial with outcomes "hit" or "no hit"
+    #     (zoops), with a constant "hit" rate within a sequence set
+    #     (p_bg in the background); expTF thus follows a binomial distribution
+    #     with the number of trials corresponding to the (weighted) number of
+    #     sequences (e.g. N_fg)
     presid <- do.call(cbind, lapply(tabL, function(tab) {
         nTotFg <- as.numeric(gsub("\\S+\\.(\\d+)\\.", "\\1", colnames(tab)[6])) #total number of target (foreground) sequences
         fracBgWithMotif <-

--- a/R/motif_enrichment_HOMER.R
+++ b/R/motif_enrichment_HOMER.R
@@ -281,7 +281,7 @@ prepareHomer <- function(gr, b, genomedir, outdir, motifFile,
 #' @param pseudofreq.pearsonResid A numerical scalar with the pseudo-frequency
 #'   to add to background frequencies when calculating Pearson residuals.
 #'   The value needs to be in [0,1] and corresponds to the minimal expected
-#'   frequency of background sequences that contain at least one motif hit.
+#'   fraction of background sequences that contain at least one motif hit.
 #' @param p.adjust.method A character scalar selecting the p value adjustment
 #'   method (used in \code{\link[stats]{p.adjust}}).
 #'
@@ -407,7 +407,7 @@ parseHomerOutput <- function(infiles,
 #' @param pseudofreq.pearsonResid A numerical scalar with the pseudo-frequency
 #'   to add to background frequencies when calculating Pearson residuals.
 #'   The value needs to be in [0,1] and corresponds to the minimal expected
-#'   frequency of background sequences that contain at least one motif hit.
+#'   fraction of background sequences that contain at least one motif hit.
 #' @param p.adjust.method A character scalar selecting the p value adjustment
 #'   method (used in \code{\link[stats]{p.adjust}}).
 #' @param Ncpu Number of parallel threads that HOMER can use.

--- a/R/motif_enrichment_kmers.R
+++ b/R/motif_enrichment_kmers.R
@@ -886,6 +886,11 @@ calcBinnedKmerEnr <- function(seqs,
     #     assuming expTF to be a Binomial random variable, with
     #       mean     = N_fg * p_bg
     #       variance = N_fg * p_bg * (1 - p_bg)
+    #     idea: each sequence is one trial with outcomes "hit" or "no hit"
+    #     (zoops), with a constant "hit" rate within a sequence set
+    #     (p_bg in the background); expTF thus follows a binomial distribution
+    #     with the number of trials corresponding to the (weighted) number of
+    #     sequences (e.g. N_fg)
     enrTF <- do.call(cbind, lapply(enrichL, function(enrich1) {
         fracBackground <-
             pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /

--- a/R/motif_enrichment_kmers.R
+++ b/R/motif_enrichment_kmers.R
@@ -559,7 +559,7 @@ clusterKmers <- function(x,
 #' @param pseudofreq.pearsonResid A numerical scalar with the pseudo-frequency
 #'   to add to background frequencies when calculating Pearson residuals.
 #'   The value needs to be in [0,1] and corresponds to the minimal expected
-#'   frequency of background sequences that contain at least one motif hit.
+#'   fraction of background sequences that contain at least one motif hit.
 #' @param p.adjust.method A character scalar selecting the p value adjustment
 #'   method (used in \code{\link[stats]{p.adjust}}).
 #' @param genome A \code{BSgenome} or \code{DNAStringSet} object with the

--- a/R/motif_enrichment_kmers.R
+++ b/R/motif_enrichment_kmers.R
@@ -907,6 +907,11 @@ calcBinnedKmerEnr <- function(seqs,
         names(enr) <- enrich1[, "motifName"]
         enr
     }))
+    if (identical(zoops, FALSE)) {
+        warning("Pearson residuals (assay 'pearsonResid') are calculated ",
+                "assumimg counts from a binomial distribion and may thus be ",
+                "incorrect for zoops=FALSE")
+    }
 
     # log2 enrichments
     log2enr <- do.call(cbind, lapply(enrichL, function(enrich1) {

--- a/R/motif_enrichment_kmers.R
+++ b/R/motif_enrichment_kmers.R
@@ -899,7 +899,7 @@ calcBinnedKmerEnr <- function(seqs,
     enrTF <- do.call(cbind, lapply(enrichL, function(enrich1) {
         fracBackground <-
             pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /
-                     enrich1[, "totalWgtBackground"] + pseudocount.pearsonResid)
+                     enrich1[, "totalWgtBackground"] + pseudofreq.pearsonResid)
         obsTF <- enrich1[, "sumForegroundWgtWithHits"]
         expTF <- enrich1[, "totalWgtForeground"] * fracBackground
         enr <- (obsTF - expTF) / sqrt(expTF * (1 - fracBackground))

--- a/R/motif_enrichment_monaLisa.R
+++ b/R/motif_enrichment_monaLisa.R
@@ -1037,7 +1037,7 @@ calcBinnedMotifEnrR <- function(seqs,
     enrTF <- do.call(cbind, lapply(enrichL, function(enrich1) {
         fracBackground <-
             pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /
-                 enrich1[, "totalWgtBackground"] + pseudocount.pearsonResid)
+                 enrich1[, "totalWgtBackground"] + pseudofreq.pearsonResid)
         obsTF <- enrich1[, "sumForegroundWgtWithHits"]
         expTF <- enrich1[, "totalWgtForeground"] * fracBackground
         enr <- (obsTF - expTF) / sqrt(expTF * (1 - fracBackground))

--- a/R/motif_enrichment_monaLisa.R
+++ b/R/motif_enrichment_monaLisa.R
@@ -734,9 +734,10 @@
 #'   the hard-coded bins used in Homer.
 #' @param pseudocount.log2enr A numerical scalar with the pseudocount to add to
 #'   foreground and background counts when calculating log2 motif enrichments
-#' @param pseudocount.pearsonResid A numerical scalar with the pseudocount to add
-#'   to foreground and background frequencies when calculating expected counts
-#'   and Pearson residuals.
+#' @param pseudofreq.pearsonResid A numerical scalar with the pseudo-frequency
+#'   to add to background frequencies when calculating Pearson residuals.
+#'   The value needs to be in [0,1] and corresponds to the minimal expected
+#'   frequency of background sequences that contain at least one motif hit.
 #' @param p.adjust.method A character scalar selecting the p value adjustment
 #'   method (used in \code{\link[stats]{p.adjust}}).
 #' @param genome A \code{BSgenome} or \code{DNAStringSet} object with the
@@ -844,7 +845,7 @@ calcBinnedMotifEnrR <- function(seqs,
                                 GCbreaks = c(0.2, 0.25, 0.3, 0.35, 0.4,
                                              0.45, 0.5, 0.6, 0.7, 0.8),
                                 pseudocount.log2enr = 8,
-                                pseudocount.pearsonResid = 0.001,
+                                pseudofreq.pearsonResid = 0.001,
                                 p.adjust.method = "BH",
                                 genome = NULL,
                                 genome.regions = NULL,
@@ -866,7 +867,7 @@ calcBinnedMotifEnrR <- function(seqs,
     .assertVector(x = pwmL, type = "PWMatrixList")
     background <- match.arg(background)
     .assertScalar(x = pseudocount.log2enr, type = "numeric", rngIncl = c(0, Inf))
-    .assertScalar(x = pseudocount.pearsonResid, type = "numeric", rngIncl = c(0, Inf))
+    .assertScalar(x = pseudofreq.pearsonResid, type = "numeric", rngIncl = c(0, 1))
     .assertScalar(x = p.adjust.method, type = "character", validValues = stats::p.adjust.methods)
     if (identical(background, "zeroBin") &&
         (!"bin0" %in% names(attributes(bins)) || is.na(attr(bins, "bin0")))) {
@@ -1030,17 +1031,21 @@ calcBinnedMotifEnrR <- function(seqs,
     padj[which(padj == Inf, arr.ind = TRUE)] <- max(padj[is.finite(padj)])
 
     # ... Pearson residuals
+    #     assuming expTF to be a Binomial random variable, with
+    #       mean     = N_fg * p_bg
+    #       variance = N_fg * p_bg * (1 - p_bg)
     enrTF <- do.call(cbind, lapply(enrichL, function(enrich1) {
-        fracForeground <- enrich1[, "sumForegroundWgtWithHits"] / enrich1[, "totalWgtForeground"]
-        fracBackground <- enrich1[, "sumBackgroundWgtWithHits"] / enrich1[, "totalWgtBackground"]
-        obsTF <- enrich1[, "sumForegroundWgtWithHits"]
-        expTF <- obsTF / (fracForeground + pseudocount.pearsonResid) * (fracBackground + pseudocount.pearsonResid)
-        enr <- (obsTF - expTF) / sqrt(expTF)
-        enr[ is.na(enr) ] <- 0
-        names(enr) <- enrich1[, "motifName"]
-        enr
+      fracBackground <-
+        pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /
+               enrich1[, "totalWgtBackground"] + pseudocount.pearsonResid)
+      obsTF <- enrich1[, "sumForegroundWgtWithHits"]
+      expTF <- enrich1[, "totalWgtForeground"] * fracBackground
+      enr <- (obsTF - expTF) / sqrt(expTF * (1 - fracBackground))
+      enr[ is.na(enr) ] <- 0 # needed for fracBackground == 1
+      names(enr) <- enrich1[, "motifName"]
+      enr
     }))
-
+    
     # log2 enrichments
     log2enr <- do.call(cbind, lapply(enrichL, function(enrich1) {
         D <- enrich1[, c("sumForegroundWgtWithHits", "sumBackgroundWgtWithHits")]
@@ -1092,7 +1097,7 @@ calcBinnedMotifEnrR <- function(seqs,
                               min.score = min.score,
                               matchMethod = matchMethod,
                               pseudocount.log2enr = pseudocount.log2enr,
-                              pseudocount.pearsonResid = pseudocount.pearsonResid,
+                              pseudofreq.pearsonResid = pseudofreq.pearsonResid,
                               p.adj.method = p.adjust.method,
                               genome.class = class(genome),
                               genome.regions = genome.regions,

--- a/R/motif_enrichment_monaLisa.R
+++ b/R/motif_enrichment_monaLisa.R
@@ -1034,6 +1034,11 @@ calcBinnedMotifEnrR <- function(seqs,
     #     assuming expTF to be a Binomial random variable, with
     #       mean     = N_fg * p_bg
     #       variance = N_fg * p_bg * (1 - p_bg)
+    #     idea: each sequence is one trial with outcomes "hit" or "no hit"
+    #     (zoops), with a constant "hit" rate within a sequence set
+    #     (p_bg in the background); expTF thus follows a binomial distribution
+    #     with the number of trials corresponding to the (weighted) number of
+    #     sequences (e.g. N_fg)
     enrTF <- do.call(cbind, lapply(enrichL, function(enrich1) {
         fracBackground <-
             pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /

--- a/R/motif_enrichment_monaLisa.R
+++ b/R/motif_enrichment_monaLisa.R
@@ -1035,17 +1035,17 @@ calcBinnedMotifEnrR <- function(seqs,
     #       mean     = N_fg * p_bg
     #       variance = N_fg * p_bg * (1 - p_bg)
     enrTF <- do.call(cbind, lapply(enrichL, function(enrich1) {
-      fracBackground <-
-        pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /
-               enrich1[, "totalWgtBackground"] + pseudocount.pearsonResid)
-      obsTF <- enrich1[, "sumForegroundWgtWithHits"]
-      expTF <- enrich1[, "totalWgtForeground"] * fracBackground
-      enr <- (obsTF - expTF) / sqrt(expTF * (1 - fracBackground))
-      enr[ is.na(enr) ] <- 0 # needed for fracBackground == 1
-      names(enr) <- enrich1[, "motifName"]
-      enr
+        fracBackground <-
+            pmin(1, enrich1[, "sumBackgroundWgtWithHits"] /
+                 enrich1[, "totalWgtBackground"] + pseudocount.pearsonResid)
+        obsTF <- enrich1[, "sumForegroundWgtWithHits"]
+        expTF <- enrich1[, "totalWgtForeground"] * fracBackground
+        enr <- (obsTF - expTF) / sqrt(expTF * (1 - fracBackground))
+        enr[ is.na(enr) ] <- 0 # needed for fracBackground == 1
+        names(enr) <- enrich1[, "motifName"]
+        enr
     }))
-    
+
     # log2 enrichments
     log2enr <- do.call(cbind, lapply(enrichL, function(enrich1) {
         D <- enrich1[, c("sumForegroundWgtWithHits", "sumBackgroundWgtWithHits")]

--- a/R/motif_enrichment_wrapper.R
+++ b/R/motif_enrichment_wrapper.R
@@ -21,7 +21,7 @@
 #' @param pseudofreq.pearsonResid A numerical scalar with the pseudo-frequency
 #'   to add to background frequencies when calculating Pearson residuals.
 #'   The value needs to be in [0,1] and corresponds to the minimal expected
-#'   frequency of background sequences that contain at least one motif hit.
+#'   fraction of background sequences that contain at least one motif hit.
 #' @param p.adjust.method A character scalar selecting the p value adjustment
 #'   method (used in \code{\link[stats]{p.adjust}}).
 #' @param BPPARAM Specifies the number of CPU cores to use for parallel

--- a/R/motif_enrichment_wrapper.R
+++ b/R/motif_enrichment_wrapper.R
@@ -18,9 +18,10 @@
 #'   enrichment calculations. One of \code{"R"} (default) or \code{"Homer"}.
 #' @param pseudocount.log2enr A numerical scalar with the pseudocount to add to
 #'   foreground and background counts when calculating log2 motif enrichments
-#' @param pseudocount.pearsonResid A numerical scalar with the pseudocount to add
-#'   to foreground and background frequencies when calculating expected counts
-#'   and Pearson residuals.
+#' @param pseudofreq.pearsonResid A numerical scalar with the pseudo-frequency
+#'   to add to background frequencies when calculating Pearson residuals.
+#'   The value needs to be in [0,1] and corresponds to the minimal expected
+#'   frequency of background sequences that contain at least one motif hit.
 #' @param p.adjust.method A character scalar selecting the p value adjustment
 #'   method (used in \code{\link[stats]{p.adjust}}).
 #' @param BPPARAM Specifies the number of CPU cores to use for parallel
@@ -63,7 +64,7 @@ calcBinnedMotifEnr <- function(seqs,
                                motifs,
                                method =  c("R", "Homer"),
                                pseudocount.log2enr = 8,
-                               pseudocount.pearsonResid = 0.001,
+                               pseudofreq.pearsonResid = 0.001,
                                p.adjust.method = "BH",
                                BPPARAM = SerialParam(),
                                verbose = FALSE,
@@ -78,7 +79,7 @@ calcBinnedMotifEnr <- function(seqs,
                                   bins = bins,
                                   pwmL = motifs,
                                   pseudocount.log2enr = pseudocount.log2enr,
-                                  pseudocount.pearsonResid = pseudocount.pearsonResid,
+                                  pseudofreq.pearsonResid = pseudofreq.pearsonResid,
                                   p.adjust.method = p.adjust.method,
                                   BPPARAM = BPPARAM,
                                   verbose = verbose,
@@ -102,7 +103,7 @@ calcBinnedMotifEnr <- function(seqs,
                                       b = bins,
                                       motifFile = motifs,
                                       pseudocount.log2enr = pseudocount.log2enr,
-                                      pseudocount.pearsonResid = pseudocount.pearsonResid,
+                                      pseudofreq.pearsonResid = pseudofreq.pearsonResid,
                                       p.adjust.method = p.adjust.method,
                                       Ncpu = ncpu,
                                       verbose = verbose,

--- a/man/calcBinnedKmerEnr.Rd
+++ b/man/calcBinnedKmerEnr.Rd
@@ -17,7 +17,7 @@ calcBinnedKmerEnr(
   GCbreaks = c(0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8),
   pseudocount.kmers = 1,
   pseudocount.log2enr = 8,
-  pseudocount.pearsonResid = 0.001,
+  pseudofreq.pearsonResid = 0.001,
   zoops = TRUE,
   p.adjust.method = "BH",
   genome = NULL,
@@ -78,9 +78,10 @@ observed and expected counts for each k-mer to avoid zero values.}
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
 
-\item{pseudocount.pearsonResid}{A numerical scalar with the pseudocount to add
-to foreground and background frequencies when calculating expected counts
-and Pearson residuals.}
+\item{pseudofreq.pearsonResid}{A numerical scalar with the pseudo-frequency
+to add to background frequencies when calculating Pearson residuals.
+The value needs to be in [0,1] and corresponds to the minimal expected
+frequency of background sequences that contain at least one motif hit.}
 
 \item{zoops}{A \code{logical} scalar. If \code{TRUE} (the default), only one
 or zero occurrences of a k-mer are considered per sequence. This is helpful

--- a/man/calcBinnedKmerEnr.Rd
+++ b/man/calcBinnedKmerEnr.Rd
@@ -18,7 +18,6 @@ calcBinnedKmerEnr(
   pseudocount.kmers = 1,
   pseudocount.log2enr = 8,
   pseudofreq.pearsonResid = 0.001,
-  zoops = TRUE,
   p.adjust.method = "BH",
   genome = NULL,
   genome.regions = NULL,
@@ -82,10 +81,6 @@ foreground and background counts when calculating log2 motif enrichments}
 to add to background frequencies when calculating Pearson residuals.
 The value needs to be in [0,1] and corresponds to the minimal expected
 frequency of background sequences that contain at least one motif hit.}
-
-\item{zoops}{A \code{logical} scalar. If \code{TRUE} (the default), only one
-or zero occurrences of a k-mer are considered per sequence. This is helpful
-to reduce the impact of simple sequence repeats occurring in few sequences.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}
@@ -166,8 +161,8 @@ This function implements a binned k-mer enrichment analysis. In each
   For each k-mer, the weights of sequences is multiplied with the number
   of k-mer occurrences in each sequence and summed, separately for foreground
   (\code{sumForegroundWgtWithHits}) and background
-  (\code{sumBackgroundWgtWithHits}) sequences. For \code{zoops = TRUE}
-  (Zero-Or-One-Per-Sequence mode, default), at most one occurrence per
+  (\code{sumBackgroundWgtWithHits}) sequences. The function works in ZOOPS
+  (Zero-Or-One-Per-Sequence) mode, so at most one occurrence per
   sequence is counted, which helps reduce the impact of sequence repeats.
   The total foreground (\code{totalWgtForeground}) and background
   (\code{totalWgtBackground}) sum of sequence weights is also calculated. If

--- a/man/calcBinnedMotifEnr.Rd
+++ b/man/calcBinnedMotifEnr.Rd
@@ -10,7 +10,7 @@ calcBinnedMotifEnr(
   motifs,
   method = c("R", "Homer"),
   pseudocount.log2enr = 8,
-  pseudocount.pearsonResid = 0.001,
+  pseudofreq.pearsonResid = 0.001,
   p.adjust.method = "BH",
   BPPARAM = SerialParam(),
   verbose = FALSE,
@@ -36,9 +36,10 @@ enrichment calculations. One of \code{"R"} (default) or \code{"Homer"}.}
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
 
-\item{pseudocount.pearsonResid}{A numerical scalar with the pseudocount to add
-to foreground and background frequencies when calculating expected counts
-and Pearson residuals.}
+\item{pseudofreq.pearsonResid}{A numerical scalar with the pseudo-frequency
+to add to background frequencies when calculating Pearson residuals.
+The value needs to be in [0,1] and corresponds to the minimal expected
+frequency of background sequences that contain at least one motif hit.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}

--- a/man/calcBinnedMotifEnrHomer.Rd
+++ b/man/calcBinnedMotifEnrHomer.Rd
@@ -13,7 +13,6 @@ calcBinnedMotifEnrHomer(
   homerfile = findHomer(),
   regionsize = "given",
   pseudocount.log2enr = 8,
-  pseudocount.pearsonResid = 0.001,
   p.adjust.method = "BH",
   Ncpu = 2L,
   verbose = FALSE,
@@ -40,10 +39,6 @@ region, an integer value will keep only that many bases in the region center).}
 
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
-
-\item{pseudocount.pearsonResid}{A numerical scalar with the pseudocount to add
-to foreground and background frequencies when calculating expected counts
-and Pearson residuals.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}

--- a/man/calcBinnedMotifEnrHomer.Rd
+++ b/man/calcBinnedMotifEnrHomer.Rd
@@ -13,6 +13,7 @@ calcBinnedMotifEnrHomer(
   homerfile = findHomer(),
   regionsize = "given",
   pseudocount.log2enr = 8,
+  pseudofreq.pearsonResid = 0.001,
   p.adjust.method = "BH",
   Ncpu = 2L,
   verbose = FALSE,
@@ -39,6 +40,11 @@ region, an integer value will keep only that many bases in the region center).}
 
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
+
+\item{pseudofreq.pearsonResid}{A numerical scalar with the pseudo-frequency
+to add to background frequencies when calculating Pearson residuals.
+The value needs to be in [0,1] and corresponds to the minimal expected
+frequency of background sequences that contain at least one motif hit.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}

--- a/man/calcBinnedMotifEnrR.Rd
+++ b/man/calcBinnedMotifEnrR.Rd
@@ -16,7 +16,7 @@ calcBinnedMotifEnrR(
   matchMethod = "matchPWM",
   GCbreaks = c(0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8),
   pseudocount.log2enr = 8,
-  pseudocount.pearsonResid = 0.001,
+  pseudofreq.pearsonResid = 0.001,
   p.adjust.method = "BH",
   genome = NULL,
   genome.regions = NULL,
@@ -66,9 +66,10 @@ the hard-coded bins used in Homer.}
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
 
-\item{pseudocount.pearsonResid}{A numerical scalar with the pseudocount to add
-to foreground and background frequencies when calculating expected counts
-and Pearson residuals.}
+\item{pseudofreq.pearsonResid}{A numerical scalar with the pseudo-frequency
+to add to background frequencies when calculating Pearson residuals.
+The value needs to be in [0,1] and corresponds to the minimal expected
+frequency of background sequences that contain at least one motif hit.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}

--- a/man/dot-calcKmerEnrichment.Rd
+++ b/man/dot-calcKmerEnrichment.Rd
@@ -4,23 +4,13 @@
 \alias{.calcKmerEnrichment}
 \title{Calculate k-mer enrichment}
 \usage{
-.calcKmerEnrichment(
-  k,
-  df,
-  zoops = TRUE,
-  test = c("fisher", "binomial"),
-  verbose = FALSE
-)
+.calcKmerEnrichment(k, df, test = c("fisher", "binomial"), verbose = FALSE)
 }
 \arguments{
 \item{k}{Numeric scalar giving the length of k-mers to analyze.}
 
 \item{df}{a \code{DataFrame} with sequence information as returned by
 \code{.iterativeNormForKmers()}.}
-
-\item{zoops}{A \code{logical} scalar. If \code{TRUE} (the default), only one
-or zero occurrences of a k-mer are considered per sequence. This is helpful
-to reduce the impact of simple sequence repeats occurring in few sequences.}
 
 \item{test}{type of motif enrichment test to perform.}
 
@@ -58,5 +48,10 @@ Given sequences, foreground/background labels and
   For \code{test = "fisher"}, \code{fisher.test} is used with
   \code{alternative = "greater"}, making it a one-sided test for enrichment,
   as is the case with the binomial test.
+}
+\details{
+The function works in ZOOPS mode, which means only one
+  or zero occurrences of a k-mer are considered per sequence. This is helpful
+  to reduce the impact of simple sequence repeats occurring in few sequences.
 }
 \keyword{internal}

--- a/man/parseHomerOutput.Rd
+++ b/man/parseHomerOutput.Rd
@@ -4,13 +4,23 @@
 \alias{parseHomerOutput}
 \title{load output from HOMER findMotifsGenome.pl into R}
 \usage{
-parseHomerOutput(infiles, pseudocount.log2enr = 8, p.adjust.method = "BH")
+parseHomerOutput(
+  infiles,
+  pseudocount.log2enr = 8,
+  pseudofreq.pearsonResid = 0.001,
+  p.adjust.method = "BH"
+)
 }
 \arguments{
 \item{infiles}{HOMER output files to be parsed.}
 
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
+
+\item{pseudofreq.pearsonResid}{A numerical scalar with the pseudo-frequency
+to add to background frequencies when calculating Pearson residuals.
+The value needs to be in [0,1] and corresponds to the minimal expected
+frequency of background sequences that contain at least one motif hit.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}

--- a/man/parseHomerOutput.Rd
+++ b/man/parseHomerOutput.Rd
@@ -4,22 +4,13 @@
 \alias{parseHomerOutput}
 \title{load output from HOMER findMotifsGenome.pl into R}
 \usage{
-parseHomerOutput(
-  infiles,
-  pseudocount.log2enr = 8,
-  pseudocount.pearsonResid = 0.001,
-  p.adjust.method = "BH"
-)
+parseHomerOutput(infiles, pseudocount.log2enr = 8, p.adjust.method = "BH")
 }
 \arguments{
 \item{infiles}{HOMER output files to be parsed.}
 
 \item{pseudocount.log2enr}{A numerical scalar with the pseudocount to add to
 foreground and background counts when calculating log2 motif enrichments}
-
-\item{pseudocount.pearsonResid}{A numerical scalar with the pseudocount to add
-to foreground and background frequencies when calculating expected counts
-and Pearson residuals.}
 
 \item{p.adjust.method}{A character scalar selecting the p value adjustment
 method (used in \code{\link[stats]{p.adjust}}).}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // countKmerPairs
 Rcpp::RObject countKmerPairs(SEXP x, int k, int n, bool zoops);
 RcppExport SEXP _monaLisa_countKmerPairs(SEXP xSEXP, SEXP kSEXP, SEXP nSEXP, SEXP zoopsSEXP) {

--- a/src/countKmerPairs.cpp
+++ b/src/countKmerPairs.cpp
@@ -295,6 +295,13 @@ Rcpp::RObject countKmerPairsSelected(SEXP x,
     for (i = 0; i <= k; i++)
         pow4[i] = pow(4, i);
     
+    if (k <= 1)
+        ::Rf_error("'k' must be greater than 1");
+    if (nk > 60000)
+        ::Rf_warning("'kmers' (%d) is large - this might take long an use a lot of memory", nk);
+    if (n < 1)
+        ::Rf_error("'n' must be greater than 0");
+
     char* seqbuffer = new char[k+1];
     seqbuffer[k] = '\0';
     Rcpp::CharacterVector kmersvect;
@@ -311,12 +318,6 @@ Rcpp::RObject countKmerPairsSelected(SEXP x,
         idx1 = kmer_index_at(seq.ptr, k, pow4);
         kmeridx2row[idx1] = i;
     }
-    if (k <= 1)
-        ::Rf_error("'k' must be greater than 1");
-    if (nk > 60000)
-        ::Rf_warning("'kmers' (%d) is large - this might take long an use a lot of memory", nk);
-    if (n < 1)
-        ::Rf_error("'n' must be greater than 0");
     
     // prepare
     // storage: column/row/value triplets used later to create a sparse matrix

--- a/tests/testthat/test_Homer.R
+++ b/tests/testthat/test_Homer.R
@@ -92,7 +92,6 @@ test_that("parseHomerOutput() works properly", {
 
     expect_error(parseHomerOutput("does-not-exist"))
     expect_error(parseHomerOutput(outfile, pseudocount.log2enr = "error"))
-    expect_error(parseHomerOutput(outfile, pseudocount.pearsonResid = -1))
     expect_error(parseHomerOutput(outfile, p.adjust.method = "error"))
     
     res <- parseHomerOutput(structure(c(outfile, outfile), names = c("bin1", "bin2")))

--- a/tests/testthat/test_Homer.R
+++ b/tests/testthat/test_Homer.R
@@ -92,6 +92,7 @@ test_that("parseHomerOutput() works properly", {
 
     expect_error(parseHomerOutput("does-not-exist"))
     expect_error(parseHomerOutput(outfile, pseudocount.log2enr = "error"))
+    expect_error(parseHomerOutput(outfile, pseudofreq.pearsonResid = "error"))
     expect_error(parseHomerOutput(outfile, p.adjust.method = "error"))
     
     res <- parseHomerOutput(structure(c(outfile, outfile), names = c("bin1", "bin2")))
@@ -107,7 +108,8 @@ test_that("parseHomerOutput() works properly", {
     expect_true(all(sapply(res[1:6], dim) == c(579L, 2L)))
     expect_length(res[[7]], 2L)
     expect_length(res[[8]], 2L)
-    expect_equal(sum(res$pearsonResid), 5344.75730637349)
+    expect_equal(sum(res$pearsonResid), 5551.72765321722)
+    expect_equal(sum(res$log2enr), 447.056685196643)
     expect_identical(res[[8]], c(bin1 = 43339, bin2 = 43339))
 })
 
@@ -202,7 +204,7 @@ test_that("calcBinnedMotifEnrHomer() works properly (synthetic data)", {
         expect_identical(apply(SummarizedExperiment::assay(res, "negLog10P"), 2, which.max),
                          c(chr1 = 1L, chr2 = 2L, chr3 = 3L))
         expect_equal(sum(SummarizedExperiment::assay(res, "negLog10P")), 65.132971396505)
-        expect_equal(sum(SummarizedExperiment::assay(res, "pearsonResid")), 68.0751984482359)
+        expect_equal(sum(SummarizedExperiment::assay(res, "pearsonResid")), 55.5841704935281)
         
         unlink(c(mfile, outdir, genomedir), recursive = TRUE, force = TRUE)
     }

--- a/tests/testthat/test_binned_motif_enrichment.R
+++ b/tests/testthat/test_binned_motif_enrichment.R
@@ -428,7 +428,7 @@ test_that("calcBinnedMotifEnrR() works (synthetic data)", {
                                dim = c(length(pwm), nlevels(b)),
                                dimnames = list(names(pwm), levels(b))))
     expect_identical(round(assay(res1, "pearsonResid"), 3),
-                     structure(c(9.271, -3.449, -3.521, 12.433, -3.853, -4.192),
+                     structure(c(10.933, -4.413, -4.374, 13.933, -5.387, -6.211),
                                dim = c(length(pwm), nlevels(b)),
                                dimnames = list(names(pwm), levels(b))))
     expect_identical(round(assay(res1, "log2enr"), 3),
@@ -444,7 +444,7 @@ test_that("calcBinnedMotifEnrR() works (synthetic data)", {
                                dim = c(length(pwm), nlevels(b)),
                                dimnames = list(names(pwm), levels(b))))
     expect_identical(round(assay(res2, "pearsonResid"), 3),
-                     structure(c(9.271, -3.449, -3.521, 12.433, -3.853, -4.192),
+                     structure(c(10.933, -4.413, -4.374, 13.933, -5.387, -6.211),
                                dim = c(length(pwm), nlevels(b)),
                                dimnames = list(names(pwm), levels(b))))
     expect_identical(round(assay(res2, "log2enr"), 3),

--- a/tests/testthat/test_binned_motif_enrichment.R
+++ b/tests/testthat/test_binned_motif_enrichment.R
@@ -362,7 +362,7 @@ test_that("calcBinnedMotifEnrR() works (synthetic data)", {
     expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, maxFracN = "error"), "numeric")
     expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, min.score = 6, maxKmerSize = "error"), "integer")
     expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, pseudocount.log2enr = "error"))
-    expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, pseudocount.pearsonResid = "error"))
+    expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, pseudofreq.pearsonResid = "error"))
     expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, p.adjust.method = "error"))
     expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, BPPARAM = "error"), "BiocParallelParam")
     expect_error(calcBinnedMotifEnrR(seqs = seqs, bins = b, pwmL = pwm, verbose = "error"), "logical")

--- a/tests/testthat/test_kmers.R
+++ b/tests/testthat/test_kmers.R
@@ -257,7 +257,7 @@ test_that("calcBinnedKmerEnr works as expected", {
     expect_error(calcBinnedKmerEnr(seqs, b, k, GCbreaks = "error"))
     expect_error(calcBinnedKmerEnr(seqs, b, k, pseudocount.kmers = -1))
     expect_error(calcBinnedKmerEnr(seqs, b, k, pseudocount.log2enr = "error"))
-    expect_error(calcBinnedKmerEnr(seqs, b, k, pseudocount.pearsonResid = "error"))
+    expect_error(calcBinnedKmerEnr(seqs, b, k, pseudofreq.pearsonResid = "error"))
     expect_error(calcBinnedKmerEnr(seqs, b, k, zoops = "error"))
     expect_error(calcBinnedKmerEnr(seqs, b, k, p.adjust.method = "error"))
     expect_error(calcBinnedKmerEnr(seqs, b, k, background = "genome",

--- a/tests/testthat/test_kmers.R
+++ b/tests/testthat/test_kmers.R
@@ -356,7 +356,7 @@ test_that("convertKmersToMotifs works as expected", {
     expect_is(a1, "SummarizedExperiment")
     expect_is(a2, "SummarizedExperiment")
     expect_identical(a1, a2)
-    expect_equal(rowSums(assay(a1, "pearsonResid")), c(`m1:::m1` = 42.1838496219965, `m2:::m2` = 0.540912980345304))
+    expect_equal(rowSums(assay(a1, "pearsonResid")), c(`m1:::m1` = 52.7476459257492, `m2:::m2` = -0.101202243464047))
 })
 
 test_that("extractOverlappingKmerFrequencies works as expected", {

--- a/tests/testthat/test_kmers.R
+++ b/tests/testthat/test_kmers.R
@@ -95,7 +95,7 @@ test_that("countKmerPairs and countKmerPairsSelected work as expected", {
     expect_error(countKmerPairsSelected(x = seqs, kmers = "error"))
     expect_error(countKmerPairsSelected(x = seqs, kmers = Biostrings::DNAStringSet(c("A","AA"))))
     expect_error(countKmerPairsSelected(x = seqs, kmers = Biostrings::DNAStringSet(c("A","A"))))
-    expect_error(expect_warning(countKmerPairsSelected(x = seqs, kmers = Biostrings::DNAStringSet(rep("AA",1001)), n = 0)))
+    expect_error(expect_warning(countKmerPairsSelected(x = seqs, kmers = Biostrings::DNAStringSet(rep("AA",60001)), n = 0)))
     expect_error(countKmerPairsSelected(x = seqs, kmers = kmers, n = 0))
 
     expect_is(res1b <- countKmerPairsSelected(x = seqs, kmers = kmers, n = 1, zoops = FALSE), "dgCMatrix")
@@ -105,6 +105,7 @@ test_that("countKmerPairs and countKmerPairsSelected work as expected", {
     expect_identical(dimnames(res1b), list(kmerschar, kmerschar))
     expect_identical(res1[kmerschar, kmerschar], res1b)
     expect_identical(res2[kmerschar, kmerschar], res2b)
+    expect_true(sum(res1b) < sum(width(seqs) - 1))
 
     ### alternative input sequences
     seqs2 <- Biostrings::DNAStringSet(c("AAANAANAANAAN"))

--- a/tests/testthat/test_kmers.R
+++ b/tests/testthat/test_kmers.R
@@ -183,24 +183,19 @@ test_that(".calcKmerEnrichment works", {
                  "'k' must be of type 'numeric'")
     expect_error(.calcKmerEnrichment(k = k, df = "error"),
                  "'df' should be a DataFrame")
-    expect_error(.calcKmerEnrichment(k = k, df = df, zoops = "error"),
-                 "'zoops' must be of type 'logical'")
-    expect_error(.calcKmerEnrichment(k = k, df = df, zoops = TRUE,
+    expect_error(.calcKmerEnrichment(k = k, df = df,
                                      test = "error"),
                  "should be one of")
-    expect_error(.calcKmerEnrichment(k = k, df = df, zoops = TRUE,
+    expect_error(.calcKmerEnrichment(k = k, df = df,
                                      test = "fisher", verbose = "error"),
                  "'verbose' must be of type 'logical'")
     
-    expect_message(res1 <- .calcKmerEnrichment(k = k, df = df, zoops = TRUE,
+    expect_message(res1 <- .calcKmerEnrichment(k = k, df = df,
                                                test = "binomial", verbose = TRUE))
-    expect_message(res2 <- .calcKmerEnrichment(k = k, df = df, zoops = FALSE,
-                                               test = "binomial", verbose = TRUE))
-    expect_message(res3 <- .calcKmerEnrichment(k = k, df = df, zoops = TRUE,
+    expect_message(res3 <- .calcKmerEnrichment(k = k, df = df,
                                                test = "fisher", verbose = TRUE))
     
     expect_is(res1, "data.frame")
-    expect_is(res2, "data.frame")
     expect_is(res3, "data.frame")
     
     expect_equal(dim(res1), c(4^k, 6))
@@ -208,8 +203,6 @@ test_that(".calcKmerEnrichment works", {
     expect_identical(res1$sumBackgroundWgtWithHits, res3$sumBackgroundWgtWithHits)
     expect_equal(res1$logP, c(-0.163497930965412, 0, -0.843717559537887, 0, 0,
                               0, 0, 0, 0, 0, -0.843717559537887, 0, 0, 0, 0, 0))
-    expect_equal(res2$logP, c(-Inf, 0, -0.843717559537887, 0, 0, 0, 0, 0, 0, 0,
-                              -Inf, 0, 0, 0, 0, 0))
     expect_equal(res3$logP, c(-0.154150679827258, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                               0, 0, 0, 0, 0))
 })


### PR DESCRIPTION
New way to calculate pearson residuals, now assuming that sequence counts
are Binomial (zoops=TRUE) rather than Poisson, and new way of using
`pseudocount.pearsonResid` (now renamed `pseudofreq.pearsonResid`),
corresponding to the minimal motif-containing frequency of background
sequences.