### PR TITLE
Fix seqlogo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: monaLisa
 Type: Package
 Title: Binned Motif Enrichment Analysis and Visualization
-Version: 1.1.2
+Version: 1.1.3
 Authors@R: c(
     person("Dania", "Machlab", email = "dania.machlab@fmi.ch", role = c("aut"), 
            comment = c(ORCID = "0000-0002-2578-6930")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     BiocParallel,
     grid,
     circlize,
-    ComplexHeatmap (>= 2.0.0),
+    ComplexHeatmap (>= 2.11.1),
     XVector,
     GenomeInfoDb,
     tools,

--- a/R/seqlogo.R
+++ b/R/seqlogo.R
@@ -301,7 +301,7 @@ annoSeqlogo <- function(grobL, which = c("column", "row"),
         var_import = list(gp, space, grobL),
         subset_rule = list(gp = ComplexHeatmap::subset_gp,
                            grobL = ComplexHeatmap::subset_vector), 
-        subsetable = TRUE
+        subsettable = TRUE
     )
     return(anno)
 }


### PR DESCRIPTION
Accommodate [changes](https://github.com/jokergoo/ComplexHeatmap/issues/897#issuecomment-1084385804) in ComplexHeatmap v2.11.1, renaming `subsetable` argument to `subsettable`.